### PR TITLE
Set Amplify Nitro preset during builds

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -7,6 +7,7 @@ frontend:
         - corepack enable && yarn install
     build:
       commands:
+        - export NITRO_PRESET=aws-amplify
         - yarn build
   artifacts:
     baseDirectory: .amplify-hosting


### PR DESCRIPTION
## Summary
- export `NITRO_PRESET=aws-amplify` before `yarn build` in the Amplify build config

## Why
- ensures Nuxt builds with the Amplify Nitro preset in the hosted build environment
- makes the build consistently emit `.amplify-hosting` output for Amplify deployment