### PR TITLE
Add analytics tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 | ✅     | Migrate to Nuxt.                        |
 | ✅     | Refresh homepage positioning and design |
 | ✅     | Optimize for mobile devices             |
-| 🕒     | Implement a contact form                |
+| ✅     | Implement a contact form                |
 | 🕒     | Add a portfolio section                 |
 | 🔄     | Add blog functionality                  |
-| 🕒     | Implement analytics to track site usage |
+| ✅     | Implement analytics to track site usage |
 | 🕒     | Include a testimonials section          |
 | 🕒     | Add a dark mode toggle                  |
 | 🕒     | Add a newsletter subscription option    |

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,6 +5,11 @@ export default defineNuxtConfig({
   modules: ['@nuxt/scripts'],
   runtimeConfig: {
     tallyApiKey: process.env.TALLY_API_KEY,
+    public: {
+      plausibleScriptSrc: process.env.PLAUSIBLE_SCRIPT_SRC || '',
+      plausibleDomain: process.env.PLAUSIBLE_DOMAIN || '',
+      plausibleApiHost: process.env.PLAUSIBLE_API_HOST || 'https://plausible.io',
+    },
   },
   experimental: {
     appManifest: false,

--- a/plugins/plausible.client.ts
+++ b/plugins/plausible.client.ts
@@ -7,34 +7,25 @@ export default defineNuxtPlugin(() => {
     return;
   }
 
-  if (plausibleScriptSrc) {
-    useHead({
-      script: [
-        {
-          async: true,
-          src: plausibleScriptSrc,
-        },
-        {
-          innerHTML:
-            "window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()",
-        },
-      ],
-    });
+  const scriptSrc = plausibleScriptSrc || (plausibleDomain
+    ? `${plausibleApiHost.replace(/\/$/, "")}/js/script.js`
+    : '');
 
-    return;
-  }
-
-  if (!plausibleDomain) {
+  if (!scriptSrc) {
     return;
   }
 
   useHead({
     script: [
       {
-        defer: true,
-        "data-domain": plausibleDomain,
-        src: `${plausibleApiHost.replace(/\/$/, "")}/js/script.js`,
+        innerHTML:
+          "window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()",
       },
+      {
+        defer: true,
+        ...(plausibleDomain ? { "data-domain": plausibleDomain } : {}),
+        src: scriptSrc,
+      }
     ],
   });
 });

--- a/plugins/plausible.client.ts
+++ b/plugins/plausible.client.ts
@@ -1,0 +1,40 @@
+export default defineNuxtPlugin(() => {
+  const {
+    public: { plausibleScriptSrc, plausibleDomain, plausibleApiHost },
+  } = useRuntimeConfig();
+
+  if (import.meta.dev) {
+    return;
+  }
+
+  if (plausibleScriptSrc) {
+    useHead({
+      script: [
+        {
+          async: true,
+          src: plausibleScriptSrc,
+        },
+        {
+          innerHTML:
+            "window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()",
+        },
+      ],
+    });
+
+    return;
+  }
+
+  if (!plausibleDomain) {
+    return;
+  }
+
+  useHead({
+    script: [
+      {
+        defer: true,
+        "data-domain": plausibleDomain,
+        src: `${plausibleApiHost.replace(/\/$/, "")}/js/script.js`,
+      },
+    ],
+  });
+});


### PR DESCRIPTION
## Summary
- add production-only Plausible analytics wiring
- support a self-hosted Plausible script URL via env var
- mark analytics as complete in the README

## Verification
- PLAUSIBLE_SCRIPT_SRC=https://plausible.subasically.me/js/pa-example.js TALLY_API_KEY=dummy yarn build
